### PR TITLE
use sociology2e for testing since recipes break

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Then try the following to build PDFs and other formats:
 # All-in-one Archive-based books
 #  CLI   tempdir       command         col_id   recipe          version   server
 ./cli.sh ./data/fizix/ all-archive-pdf col12006 college-physics latest
-./cli.sh ./data/socio/ all-archive-pdf col11407 sociology       latest
-./cli.sh ./data/socio/ all-archive-web col11407 sociology       latest
+./cli.sh ./data/socio/ all-archive-pdf col11762 sociology       latest
+./cli.sh ./data/socio/ all-archive-web col11762 sociology       latest
 ```
 
 **Note:** If you are running this inside a container (like gitpod) then you can replace `./cli.sh ./data/tin-bk/` with `./dockerfiles/docker-entrypoint.sh` (no data directory necessary, it will be `/data/`)
@@ -167,7 +167,7 @@ If you want to run a single step at a time specify it as the first argument. Lat
 
 ```sh
 # Common steps
-./cli.sh ./data/socio/ local-create-book-directory col11407 sociology latest
+./cli.sh ./data/socio/ local-create-book-directory col11762 sociology latest
 ./cli.sh ./data/socio/ look-up-book
 ./cli.sh ./data/socio/ archive-fetch
 ./cli.sh ./data/socio/ archive-assemble

--- a/google-docs.md
+++ b/google-docs.md
@@ -43,7 +43,7 @@ In https://drive.google.com create a new Folder (e.g. “Test GDocs Root” ) an
 Use the book-pipeline CLI to generate DOCX files for a book. For example: (the exact syntax is subject to change):
 
 ```sh
-./cli.js ./data/socio all-archive-gdoc col11407 sociology latest
+./cli.js ./data/socio all-archive-gdoc col11762 sociology latest
 ```
 
 ## Upload the DOCX files to Google Drive

--- a/test/test-step-04.bash
+++ b/test/test-step-04.bash
@@ -7,7 +7,7 @@ SOCI_DIR=../data/test-soci
 
 SKIP_DOCKER_BUILD=1 \
 KCOV_DIR=_kcov04-a \
-../cli.sh $SOCI_DIR all-archive-web col11407 sociology latest
+../cli.sh $SOCI_DIR all-archive-web col11762 sociology latest
 
 SKIP_DOCKER_BUILD=1 \
 KCOV_DIR=_kcov04-b \


### PR DESCRIPTION
The newer sociology recipe will break these tests because it assumes `(2e)` is in the title. This unblocks upgrading the recipes submodule